### PR TITLE
Refactor signature pad IDs and config usage in docs

### DIFF
--- a/docs/advanced-usage.html
+++ b/docs/advanced-usage.html
@@ -114,7 +114,7 @@ const signaturePad = new SignaturePad(canvas, {
                         </div>
                     </div>
                     <div class="controls">
-                        <button class="btn btn-secondary" onclick="signaturePads.config.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['config-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="config-status">Canvas is empty</div>
                     </div>
                 </div>
@@ -166,7 +166,7 @@ signaturePad.addEventListener('endStroke', function(event) {
                         </div>
                     </div>
                     <div class="controls">
-                        <button class="btn btn-secondary" onclick="signaturePads.events.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['events-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="events-status">Canvas is empty</div>
                     </div>
                     <div class="output-section">
@@ -224,7 +224,7 @@ signaturePad.fromDataURL(savedSignature);
                         <button class="btn btn-primary" onclick="exportSignature('svg')">Export SVG</button>
                         <button class="btn btn-info" onclick="saveSignature()">Save to Memory</button>
                         <button class="btn btn-success" onclick="loadSignature()">Load from Memory</button>
-                        <button class="btn btn-secondary" onclick="signaturePads.export.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['export-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="export-status">Canvas is empty</div>
                     </div>
                     <div class="output-section">
@@ -285,7 +285,7 @@ function cleanup() {
                         </div>
                     </div>
                     <div class="controls">
-                        <button class="btn btn-secondary" onclick="signaturePads.performance.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['performance-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="performance-status">Canvas is empty</div>
                     </div>
                 </div>
@@ -407,10 +407,10 @@ function validateAllSignatures() {
         // Initialize signature pads when page loads
         document.addEventListener('DOMContentLoaded', function() {
             signaturePads.init([
-                { id: 'config', config: { backgroundColor: '#ffffff', penColor: '#000000' } },
+                { id: 'config-pad', options: { backgroundColor: '#ffffff', penColor: '#000000' } },
                 { 
-                    id: 'events', 
-                    config: {
+                    id: 'events-pad', 
+                    options: {
                         onBegin: function() {
                             logEvent('Drawing started');
                         },
@@ -419,17 +419,17 @@ function validateAllSignatures() {
                         }
                     }
                 },
-                { id: 'export', config: {} },
-                { id: 'performance', config: { throttle: 8, minPointDistance: 3, velocityFilterWeight: 0.9 } },
-                { id: 'customer', config: { penColor: '#3182ce' } },
-                { id: 'witness', config: { penColor: '#e53e3e' } },
-                { id: 'agent', config: { penColor: '#38a169' } }
+                { id: 'export-pad', options: {} },
+                { id: 'performance-pad', options: { throttle: 8, minPointDistance: 3, velocityFilterWeight: 0.9 } },
+                { id: 'customer-pad', options: { penColor: '#3182ce' } },
+                { id: 'witness-pad', options: { penColor: '#e53e3e' } },
+                { id: 'agent-pad', options: { penColor: '#38a169' } }
             ]);
         });
 
         // Configuration functions
         function updateConfig(property, value) {
-            const pad = signaturePads.config;
+            const pad = signaturePads['config-pad'];
             if (pad) {
                 pad[property] = value;
                 updateConfigCode();
@@ -468,7 +468,7 @@ const signaturePad = new SignaturePad(canvas, {
 
         // Export functions
         function exportSignature(format) {
-            const pad = signaturePads.export;
+            const pad = signaturePads['export-pad'];
             if (pad.isEmpty()) {
                 alert('Please draw a signature first!');
                 return;
@@ -497,7 +497,7 @@ const signaturePad = new SignaturePad(canvas, {
         }
 
         function saveSignature() {
-            const pad = signaturePads.export;
+            const pad = signaturePads['export-pad'];
             if (pad.isEmpty()) {
                 alert('Please draw a signature first!');
                 return;
@@ -511,13 +511,13 @@ const signaturePad = new SignaturePad(canvas, {
                 alert('No signature data saved! Please save a signature first.');
                 return;
             }
-            signaturePads.export.fromDataURL(savedSignatureData);
+            signaturePads['export-pad'].fromDataURL(savedSignatureData);
             alert('Signature loaded from memory!');
         }
 
         // Multiple pads functions
         function validateAllPads() {
-            const pads = ['customer', 'witness', 'agent'];
+            const pads = ['customer-pad', 'witness-pad', 'agent-pad'];
             const results = pads.map(id => ({
                 id,
                 isEmpty: signaturePads[id].isEmpty()
@@ -531,14 +531,14 @@ const signaturePad = new SignaturePad(canvas, {
         }
 
         function clearAllPads() {
-            ['customer', 'witness', 'agent'].forEach(id => {
+            ['customer-pad', 'witness-pad', 'agent-pad'].forEach(id => {
                 signaturePads[id].clear();
             });
         }
 
         function exportAllPads() {
             const results = {};
-            ['customer', 'witness', 'agent'].forEach(id => {
+            ['customer-pad', 'witness-pad', 'agent-pad'].forEach(id => {
                 if (!signaturePads[id].isEmpty()) {
                     results[id] = signaturePads[id].toDataURL();
                 }

--- a/docs/basic-usage.html
+++ b/docs/basic-usage.html
@@ -70,7 +70,7 @@ document.getElementById('clear').addEventListener('click', () => {
                         </div>
                     </div>
                     <div class="controls">
-                        <button class="btn btn-secondary" onclick="signaturePads.basic.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['basic-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="basic-status">Canvas is empty</div>
                     </div>
                 </div>
@@ -111,9 +111,9 @@ signaturePad.backgroundColor = '#fff5f5';  // Light red background
                         <div class="control-group">
                             <label>Pen Color:</label>
                             <input type="color" value="#3182ce" class="color-picker" 
-                                   onchange="signaturePads.customColors.penColor = this.value">
+                                   onchange="signaturePads['custom-colors-pad'].penColor = this.value">
                         </div>
-                        <button class="btn btn-secondary" onclick="signaturePads.customColors.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['custom-colors-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="custom-colors-status">Canvas is empty</div>
                     </div>
                 </div>
@@ -153,14 +153,14 @@ signaturePad.maxWidth = 4;
                         <div class="control-group">
                             <label>Min Width: <span id="min-width-value">2</span></label>
                             <input type="range" min="0.5" max="5" step="0.5" value="2" class="thickness-slider"
-                                   oninput="signaturePads.thickStrokes.minWidth = this.value; document.getElementById('min-width-value').textContent = this.value">
+                                   oninput="signaturePads['thick-strokes-pad'].minWidth = this.value; document.getElementById('min-width-value').textContent = this.value">
                         </div>
                         <div class="control-group">
                             <label>Max Width: <span id="max-width-value">5</span></label>
                             <input type="range" min="1" max="10" step="0.5" value="5" class="thickness-slider"
-                                   oninput="signaturePads.thickStrokes.maxWidth = this.value; document.getElementById('max-width-value').textContent = this.value">
+                                   oninput="signaturePads['thick-strokes-pad'].maxWidth = this.value; document.getElementById('max-width-value').textContent = this.value">
                         </div>
-                        <button class="btn btn-secondary" onclick="signaturePads.thickStrokes.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['thick-strokes-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="thick-strokes-status">Canvas is empty</div>
                     </div>
                 </div>
@@ -204,7 +204,7 @@ signaturePad.on();   // Enable
                     </div>
                     <div class="controls">
                         <button class="btn btn-primary" onclick="downloadSignature('methods')">Download PNG</button>
-                        <button class="btn btn-secondary" onclick="signaturePads.methods.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['methods-pad'].clear()">Clear</button>
                         <button class="btn btn-info" onclick="togglePad('methods')" id="toggle-methods">Disable Drawing</button>
                         <div class="status-indicator status-empty" id="methods-status">Canvas is empty</div>
                     </div>
@@ -246,7 +246,7 @@ resizeCanvas(); // Initialize
                         </div>
                     </div>
                     <div class="controls">
-                        <button class="btn btn-secondary" onclick="signaturePads.responsive.clear()">Clear</button>
+                        <button class="btn btn-secondary" onclick="signaturePads['responsive-pad'].clear()">Clear</button>
                         <div class="status-indicator status-empty" id="responsive-status">Canvas is empty</div>
                     </div>
                 </div>
@@ -296,7 +296,7 @@ document.getElementById('signature-form').addEventListener('submit', (e) => {
                         <input type="hidden" name="signature" id="form-signature-data">
                         <div class="controls">
                             <button type="submit" class="btn btn-success">Submit Form</button>
-                            <button type="button" class="btn btn-secondary" onclick="signaturePads.form.clear()">Clear</button>
+                            <button type="button" class="btn btn-secondary" onclick="signaturePads['form-pad'].clear()">Clear</button>
                             <div class="status-indicator status-empty" id="form-status">Canvas is empty</div>
                         </div>
                     </form>
@@ -339,12 +339,12 @@ document.getElementById('signature-form').addEventListener('submit', (e) => {
         document.addEventListener('DOMContentLoaded', function() {
             // Initialize all signature pads with different configurations
             signaturePads.init([
-                { id: 'basic', config: {} },
-                { id: 'customColors', config: { penColor: '#3182ce', backgroundColor: '#f7fafc' } },
-                { id: 'thickStrokes', config: { minWidth: 2, maxWidth: 5 } },
-                { id: 'methods', config: {} },
-                { id: 'responsive', config: {} },
-                { id: 'form', config: {} }
+                { id: 'basic-pad', options: {} },
+                { id: 'custom-colors-pad', options: { penColor: '#3182ce', backgroundColor: '#f7fafc' } },
+                { id: 'thick-strokes-pad', options: { minWidth: 2, maxWidth: 5 } },
+                { id: 'methods-pad', options: {} },
+                { id: 'responsive-pad', options: {} },
+                { id: 'form-pad', options: {} }
             ]);
         });
 
@@ -381,7 +381,7 @@ document.getElementById('signature-form').addEventListener('submit', (e) => {
 
         function handleFormSubmit(event) {
             event.preventDefault();
-            const pad = signaturePads.form;
+            const pad = signaturePads['form-pad'];
             
             if (pad.isEmpty()) {
                 alert('Please provide a signature first.');

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -239,8 +239,8 @@ No data exported yet. Use the export buttons above to see output here.
         document.addEventListener('DOMContentLoaded', function() {
             signaturePads.init([
                 { 
-                    id: 'main', 
-                    config: {
+                    id: 'main-pad', 
+                    options: {
                         penColor: '#000000',
                         backgroundColor: '#ffffff',
                         minWidth: 0.5,
@@ -259,7 +259,7 @@ No data exported yet. Use the export buttons above to see output here.
                     }
                 }
             ]);
-            mainPad = signaturePads.main;
+            mainPad = signaturePads['main-pad'];
         });
 
         // Update functions

--- a/docs/index.html
+++ b/docs/index.html
@@ -452,7 +452,7 @@ if (signaturePad.isEmpty()) {
         function initSignaturePads() {
             // Quick demo pad
             signaturePads.init([
-                { id: 'quick-signature-container', config: { penColor: '#3182ce', minWidth: 2, maxWidth: 4 } }
+                { id: 'quick-signature-container', options: { penColor: '#3182ce', minWidth: 2, maxWidth: 4 } }
             ]);
         }        // Page-specific initialization
         document.addEventListener('DOMContentLoaded', () => {

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -628,9 +628,9 @@ requiredMethods.forEach(method => {
         function initSignaturePads() {
             // Initialize the verification demo pads
             signaturePads.init([
-                { id: 'npm-signature-container', config: { penColor: '#3182ce', minWidth: 1, maxWidth: 3 } },
-                { id: 'cdn-signature-container', config: { penColor: '#e53e3e', minWidth: 2, maxWidth: 4 } },
-                { id: 'local-signature-container', config: { penColor: '#38a169', minWidth: 1.5, maxWidth: 3.5 } }
+                { id: 'npm-signature-container', options: { penColor: '#3182ce', minWidth: 1, maxWidth: 3 } },
+                { id: 'cdn-signature-container', options: { penColor: '#e53e3e', minWidth: 2, maxWidth: 4 } },
+                { id: 'local-signature-container', options: { penColor: '#38a169', minWidth: 1.5, maxWidth: 3.5 } }
             ]);
         }
 


### PR DESCRIPTION
Updated all documentation HTML files to use new signature pad IDs with '-pad' suffix and replaced 'config' with 'options' for initialization. Adjusted all references and event handlers to match the new naming convention. Enhanced shared.js to provide a global signaturePads manager, improved pad initialization, and added convenience methods for pad access and actions.